### PR TITLE
Fixed an error when running sync

### DIFF
--- a/lib/ftpsync.js
+++ b/lib/ftpsync.js
@@ -215,7 +215,7 @@ var sync = exports = {
             sync.log.error('MKDIRs failed.');
             callback(err);
           }
-          sync.info('MKDIRs complete.');
+          sync.log.info('MKDIRs complete.');
           callback(null);
         });
       },


### PR DESCRIPTION
Looks like info was called on the sync object directly rather than on the log.
