### PR TITLE
fix for big files sync

### DIFF
--- a/lib/ftpsync.js
+++ b/lib/ftpsync.js
@@ -463,23 +463,15 @@ var utils = exports.utils = {
     });*/
     var local = settings.local + file;
     var remote = settings.remote + file;
-    fs.readFile(local, function(err, buffer) {
-      if(err) {
-        sync.log.error('fs.readFile failed.');
+    ftp.put(buffer, remote, function(err) {
+      if (err) {
+        sync.log.error('ftp.put failed.');
         callback(err);
       }
-      else {
-        ftp.put(buffer, remote, function(err) {
-          if (err) {
-            sync.log.error('ftp.put failed.');
-            callback(err);
-          }
-          if (sync.log.verbose) {
-            sync.log.write('-', file, 'uploaded successfuly');
-          }
-          callback();
-        });
+      if (sync.log.verbose) {
+        sync.log.write('-', file, 'uploaded successfuly');
       }
+      callback();
     });
   },
 

--- a/lib/ftpsync.js
+++ b/lib/ftpsync.js
@@ -463,7 +463,7 @@ var utils = exports.utils = {
     });*/
     var local = settings.local + file;
     var remote = settings.remote + file;
-    ftp.put(buffer, remote, function(err) {
+    ftp.put(local, remote, function(err) {
       if (err) {
         sync.log.error('ftp.put failed.');
         callback(err);


### PR DESCRIPTION
If we read file into the buffer and the file is big (a few GBs) the ftpsync crashes. So no need to read the file with fs.readFile. jsftp can be used with just a filename as a parameter and with it the syncing works file with big files. Big files support would be a great feature for backup solutions (which I use it for:))