### PR TITLE
Minor update to default settings to fix crash

### DIFF
--- a/lib/ftpsync.js
+++ b/lib/ftpsync.js
@@ -61,6 +61,11 @@ var sync = exports = {
     if (!settings.host) { sync.log.warn("Host name not set"); }
     if (!settings.user) { sync.log.warn("User name not set"); }
     if (!settings.pass) { sync.log.warn("Password not set"); }
+    
+    // sensible defaults
+    settings.ignore = settings.ignore || [];
+    settings.connections = settings.connections || 1;
+    
     // display the settings
     if (sync.log.verbose) {
       sync.log.write('Settings:');


### PR DESCRIPTION
If settings.ignore not specified by user, this fixes a crash.
If settings.connections not specified by user, this defaults to 1 so the lib still works.