### PR TITLE
Create remote root dir if necessary and specified in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Contains the application settings for ftpsync.
   - `remoteRoot` - the root path of the remote server (default `'./'`).
   - `connections` - the max number of concurrent ftp connections (default `1`).
   - `ignore` - the list of file patterns to ignore.
+  - `createRemoteDir` - set to 'true' to create the remote root directory if necessary
 
 *Note: Ignore patterns can be defined as a filename, file path, or glob match.*
 

--- a/lib/ftpsync.js
+++ b/lib/ftpsync.js
@@ -98,6 +98,14 @@ var sync = exports = {
       },
       function(callback) {
         utils.walkRemote(settings.remote, callback);
+      },
+      function(callback) {
+        // create remote dir if necessary.
+        if (settings.createRemoteDir) {
+          utils.createRemoteDir(settings.remote, callback);
+        } else {
+          callback();
+        }
       }
     ], function(err, results) {
       if (err) {
@@ -372,6 +380,22 @@ var utils = exports.utils = {
           else { next(); }
         });
       })();
+    });
+  },
+
+  createRemoteDir: function(dir, callback) {
+    if (dir.substring(0, 1) == '/') {
+      dir = dir.substring(1);
+    }
+    // Try to create dir. even if it exists.  If so, no harm done.
+    ftp.raw.mkd(dir, function(err, data) {
+      if (err && sync.log.verbose) {
+        sync.log.error('MKDIR root error: ', err);
+      }
+      if (data && sync.log.verbose) {
+        sync.log.write('MKDIR response: ', data);
+      }
+      callback();
     });
   },
 


### PR DESCRIPTION
I'll admit it's not super elegant.  It just tries to create the remote root dir regardless of whether it exists already or not.  If it does, this will just silently fail with no harm done.  This feature was required for my project.
