### PR TITLE
Fatal error: Callback was already called:

### DIFF
--- a/lib/ftpsync.js
+++ b/lib/ftpsync.js
@@ -79,7 +79,7 @@ var sync = exports = {
     catch(err) {
       sync.log.error('Setup failed.');
       sync.log.write('');
-      callback(err);
+      return callback(err);
     }
     sync.log.info('Setup complete.');
     sync.log.write('');
@@ -103,7 +103,7 @@ var sync = exports = {
       if (err) {
         sync.log.error('Collection failed.');
         sync.log.write('');
-        callback(err);
+        return callback(err);
       }
       // store the values for later
       sync.local = results[0];
@@ -213,7 +213,7 @@ var sync = exports = {
         async.mapLimit(sync.mkdir, 1, utils.mkdir, function (err) {
           if (err) {
             sync.log.error('MKDIRs failed.');
-            callback(err);
+            return callback(err);
           }
           sync.log.info('MKDIRs complete.');
           callback(null);
@@ -225,7 +225,7 @@ var sync = exports = {
         async.mapLimit(sync.add, settings.connections, utils.upload, function (err) {
           if (err) {
             sync.log.error('Additions failed.');
-            callback(err);
+            return callback(err);
           }
           sync.log.info('Additions complete.');
           callback(null);
@@ -237,7 +237,7 @@ var sync = exports = {
         async.mapLimit(sync.update, settings.connections, utils.upload, function (err) {
           if (err) {
             sync.log.error('Updates failed.');
-            callback(err);
+            return callback(err);
           }
           sync.log.info('Updates complete.');
           callback(null);
@@ -249,7 +249,7 @@ var sync = exports = {
         async.mapLimit(sync.remove, 1, utils.remove, function (err) {
           if (err) {
             sync.log.error('Removals failed.');
-            callback(err);
+            return callback(err);
           }
           sync.log.info('Removals complete');
           callback(null);
@@ -261,7 +261,7 @@ var sync = exports = {
         async.mapLimit(sync.rmdir, 1, utils.rmdir, function (err) {
           if (err) {
             sync.log.error('RMDIRs failed.');
-            callback(err);
+            return callback(err);
           }
           sync.log.info('RMDIRs complete.');
           callback(null);
@@ -271,7 +271,7 @@ var sync = exports = {
     function(err, results) {
       if (err) {
         sync.log.error('Commit failed.');
-        callback(err);
+        return callback(err);
       }
       sync.log.info('Commit complete.');
       callback(null);
@@ -430,7 +430,7 @@ var utils = exports.utils = {
     ftp.raw.mkd(dir, function(err, data) {
       if (err) {
         sync.log.error('MKDIR failed.');
-        callback(err);
+        return callback(err);
       }
       if (sync.log.verbose) {
         sync.log.write('-', dir, 'created successfuly');
@@ -444,7 +444,7 @@ var utils = exports.utils = {
     ftp.raw.rmd(dir, function(err, data) {
       if (err) {
         sync.log.error('RMDIR failed.');
-        callback(err);
+        return callback(err);
       }
       if (sync.log.verbose) {
         sync.log.write('-', dir, 'deleted successfuly');
@@ -466,13 +466,13 @@ var utils = exports.utils = {
     fs.readFile(local, function(err, buffer) {
       if(err) {
         sync.log.error('fs.readFile failed.');
-        callback(err);
+        return callback(err);
       }
       else {
         ftp.put(buffer, remote, function(err) {
           if (err) {
             sync.log.error('ftp.put failed.');
-            callback(err);
+            return callback(err);
           }
           if (sync.log.verbose) {
             sync.log.write('-', file, 'uploaded successfuly');
@@ -488,7 +488,7 @@ var utils = exports.utils = {
     ftp.raw.dele(file, function(err, data) {
       if (err) {
         sync.log.error('Remove failed.');
-        callback(err);
+        return callback(err);
       }
       if (sync.log.verbose) {
         sync.log.write('-', file, 'deleted successfuly');


### PR DESCRIPTION
Hi,

In some cases, we get: "Fatal error: Callback was already called" error message.

I think "return" should be adding when calling a callback early as mentioned in https://github.com/caolan/async#multiple-callbacks

Thanks

Ludovic

