### PR TITLE
Log results shouldn't be verbose

### DIFF
--- a/lib/ftpsync.js
+++ b/lib/ftpsync.js
@@ -184,23 +184,22 @@ var sync = exports = {
     });
 
     // log the results
-    if (sync.log.verbose) {
-      sync.log.write('Mkdir:');
-      sync.log.write(sync.mkdir);
-      sync.log.write('');
-      sync.log.write('Rmdir:');
-      sync.log.write(sync.rmdir);
-      sync.log.write('');
-      sync.log.write('Add:');
-      sync.log.write(sync.add);
-      sync.log.write('');
-      sync.log.write('Updates:');
-      sync.log.write(sync.update);
-      sync.log.write('');
-      sync.log.write('Remove:');
-      sync.log.write(sync.remove);
-      sync.log.write('');
-    }
+    sync.log.write('Mkdir:');
+    sync.log.write(sync.mkdir);
+    sync.log.write('');
+    sync.log.write('Rmdir:');
+    sync.log.write(sync.rmdir);
+    sync.log.write('');
+    sync.log.write('Add:');
+    sync.log.write(sync.add);
+    sync.log.write('');
+    sync.log.write('Updates:');
+    sync.log.write(sync.update);
+    sync.log.write('');
+    sync.log.write('Remove:');
+    sync.log.write(sync.remove);
+    sync.log.write('');
+    
     sync.log.info('Consolidation complete.');
     sync.log.write('');
     callback(null);


### PR DESCRIPTION
All the stuff before makes sense to be verbose, logging what files that were handled doesn't. For instance, when you run this module you can't see what files have gone up. You can do this by turning on verbose but then you are getting a lot more information you don't need. I feel the files being handled should always be logged.
