### PR TITLE
updating project dependencies to the latest versions (and fixing DeprecationWarning: Ftp.raw[user](args): Use Ftp.raw('user args') instead)

### DIFF
--- a/lib/ftpsync.js
+++ b/lib/ftpsync.js
@@ -438,7 +438,7 @@ var utils = exports.utils = {
 
   mkdir: function(dir, callback) {
     dir = settings.remote + dir;
-    ftp.raw.mkd(dir, function(err, data) {
+    ftp.raw("mkd",dir, function(err, data) {
       if (err) {
         sync.log.error('MKDIR failed.');
         return callback(err);
@@ -452,7 +452,7 @@ var utils = exports.utils = {
 
   rmdir: function(dir, callback) {
     dir = settings.remote + dir;
-    ftp.raw.rmd(dir, function(err, data) {
+    ftp.raw("rmd",dir, function(err, data) {
       if (err) {
         sync.log.error('RMDIR failed.');
         return callback(err);
@@ -482,7 +482,7 @@ var utils = exports.utils = {
 
   remove: function(file, callback) {
     file = settings.remote + file;
-    ftp.raw.dele(file, function(err, data) {
+    ftp.raw("dele",file, function(err, data) {
       if (err) {
         sync.log.error('Remove failed.');
         return callback(err);

--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
     "node": "*"
   },
   "dependencies": {
-    "async": "^1.5.1",
-    "commander": "^2.9.0",
-    "jsftp": "1.5.5",
-    "minimatch": "^3.0.0",
-    "touch": "^1.0.0"
+    "async": "^2.6.0",
+    "commander": "^2.15.1",
+    "jsftp": "2.1.3",
+    "minimatch": "^3.0.4",
+    "touch": "^3.1.0"
   },
   "devDependencies": {
-    "ftpd": "^0.2.12",
-    "grunt": "^0.4.5",
-    "grunt-contrib-clean": "^0.7.0",
-    "grunt-contrib-jshint": "^0.11.3",
-    "grunt-contrib-nodeunit": "^0.4.1"
+    "ftpd": "^0.2.15",
+    "grunt": "^1.0.2",
+    "grunt-contrib-clean": "^1.1.0",
+    "grunt-contrib-jshint": "^1.1.0",
+    "grunt-contrib-nodeunit": "^1.0.0"
   }
 }


### PR DESCRIPTION
I'm bumping project dependencies. It should fix #40 and #41.  Problem mentioned in these issues was fixed in https://github.com/sergi/jsftp/issues/226 (`jsftp` v. **2.0.0**). I bumped `jsftp` to **2.1.3**, which is the latest version of this library. Moreover, I've tested it after that update in my own project and I haven't noticed any warnings, so I can confirm it should solve this problem.